### PR TITLE
Disable unreliable end-to-end workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,43 +48,43 @@ jobs:
           path: coverage/
           retention-days: 7
 
-  e2e-tests:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-      - name: Build card
-        run: npm run build
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Start test environment
-        run: |
-          docker compose -f docker-compose.test.yml up -d
-          # Wait for Home Assistant to be ready
-          timeout 300 bash -c 'until curl -f http://localhost:8123; do sleep 5; done'
-      - name: Run E2E tests
-        run: npm run test:e2e
-        env:
-          CI: true
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: e2e-test-results
-          path: |
-            test-results/
-            playwright-report/
-          retention-days: 7
-      - name: Cleanup
-        if: always()
-        run: docker compose -f docker-compose.test.yml down
+  # e2e-tests:
+  #   name: E2E Tests
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 15
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #     - name: Setup Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '18'
+  #         cache: 'npm'
+  #     - name: Install dependencies
+  #       run: npm ci --legacy-peer-deps
+  #     - name: Install Playwright Browsers
+  #       run: npx playwright install --with-deps
+  #     - name: Build card
+  #       run: npm run build
+  #     - name: Setup Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+  #     - name: Start test environment
+  #       run: |
+  #         docker compose -f docker-compose.test.yml up -d
+  #         # Wait for Home Assistant to be ready
+  #         timeout 300 bash -c 'until curl -f http://localhost:8123; do sleep 5; done'
+  #     - name: Run E2E tests
+  #       run: npm run test:e2e
+  #       env:
+  #         CI: true
+  #     - name: Upload test results
+  #       uses: actions/upload-artifact@v4
+  #       if: always()
+  #       with:
+  #         name: e2e-test-results
+  #         path: |
+  #           test-results/
+  #           playwright-report/
+  #         retention-days: 7
+  #     - name: Cleanup
+  #       if: always()
+  #       run: docker compose -f docker-compose.test.yml down

--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -42,30 +42,30 @@ jobs:
         env:
           CI: true
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      # - name: Install Playwright Browsers
+      #   run: npx playwright install --with-deps
 
-      - name: Build card
-        run: npm run build
+      # - name: Build card
+      #   run: npm run build
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Setup Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
 
-      - name: Start test environment for E2E
-        run: |
-          docker compose -f docker-compose.test.yml up -d
-          # Wait for Home Assistant to be ready
-          timeout 300 bash -c 'until curl -f http://localhost:8123; do sleep 5; done'
+      # - name: Start test environment for E2E
+      #   run: |
+      #     docker compose -f docker-compose.test.yml up -d
+      #     # Wait for Home Assistant to be ready
+      #     timeout 300 bash -c 'until curl -f http://localhost:8123; do sleep 5; done'
 
-      - name: Run E2E tests
-        run: npm run test:e2e
-        env:
-          CI: true
-        continue-on-error: true  # Don't fail the job if E2E tests fail
+      # - name: Run E2E tests
+      #   run: npm run test:e2e
+      #   env:
+      #     CI: true
+      #   continue-on-error: true  # Don't fail the job if E2E tests fail
 
-      - name: Cleanup test environment
-        if: always()
-        run: docker compose -f docker-compose.test.yml down
+      # - name: Cleanup test environment
+      #   if: always()
+      #   run: docker compose -f docker-compose.test.yml down
 
       - name: SonarQube Scan
         uses: sonarqube-quality-gate-action@master

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -31,54 +31,54 @@ jobs:
         uses: codecov/codecov-action@v3
         if: always()
 
-  e2e-tests:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
+  # e2e-tests:
+  #   name: E2E Tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v5
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
+  #     - name: Setup Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '18'
+  #         cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+  #     - name: Install dependencies
+  #       run: npm ci --legacy-peer-deps
 
-      - name: Install Playwright browsers (with dependencies)
-        run: npx playwright install --with-deps
+  #     - name: Install Playwright browsers (with dependencies)
+  #       run: npx playwright install --with-deps
 
-      - name: Build card
-        run: npm run build
+  #     - name: Build card
+  #       run: npm run build
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Setup Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Start test environment
-        run: |
-          docker compose -f docker-compose.test.yml up -d
-          # Wait for Home Assistant to be ready
-          timeout 300 bash -c 'until curl -f http://localhost:8123; do sleep 5; done'
+  #     - name: Start test environment
+  #       run: |
+  #         docker compose -f docker-compose.test.yml up -d
+  #         # Wait for Home Assistant to be ready
+  #         timeout 300 bash -c 'until curl -f http://localhost:8123; do sleep 5; done'
 
-      - name: Run E2E tests
-        run: npm run test:e2e
-        env:
-          CI: true
+  #     - name: Run E2E tests
+  #       run: npm run test:e2e
+  #       env:
+  #         CI: true
 
-      - name: Cleanup test environment
-        if: always()
-        run: docker compose -f docker-compose.test.yml down
+  #     - name: Cleanup test environment
+  #       if: always()
+  #       run: docker compose -f docker-compose.test.yml down
 
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: playwright-results
-          path: |
-            test-results/
-            playwright-report/
-          retention-days: 5
+  #     - name: Upload test results
+  #       uses: actions/upload-artifact@v4
+  #       if: always()
+  #       with:
+  #         name: playwright-results
+  #         path: |
+  #           test-results/
+  #           playwright-report/
+  #         retention-days: 5
 
   build:
     name: Build Check


### PR DESCRIPTION
Disable E2E workflows across all GitHub Actions files because they are unreliable and costly.

---
<a href="https://cursor.com/background-agent?bcId=bc-17628ff8-2a89-4dcb-9f60-a4da64421a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17628ff8-2a89-4dcb-9f60-a4da64421a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

